### PR TITLE
IMU class template

### DIFF
--- a/Common/Inc/CommonDataTypes.hpp
+++ b/Common/Inc/CommonDataTypes.hpp
@@ -1,21 +1,35 @@
-//
-// Created by Gordon Fountain 2022-11-30.
-//
+/** CommonDataTypes.hpp
+ * Contains a bunch of common datatypes!
+ * 
+ * Created by: Gordon Fountain 2022-11-30
+ * Updated by: Anthony Luo
+ * Last update: 2024-04-18
+*/
 
 #ifndef ZPSW3_COMMON_DATATYPES_HPP
 #define ZPSW3_COMMON_DATATYPES_HPP
 
 #include <stdint.h>
 
-namespace AM {
+/************************************************
+ * Sensor/Error structs (can be either or. tbd ig)
+ ************************************************/
+typedef enum SensorErrorCode {
+    SENSOR_SUCCESS = 0,
+    SENSOR_FAIL = -1,
+    SENSOR_BUSY = 1,
+} SensorErrorCode;
 
+/************************************************
+ * Control limits & inter-manager datatypes
+ ************************************************/
+namespace AM {
 struct AttitudeManagerInput {
     float roll;
     float pitch;
     float yaw;
     float throttle;
 };
-
 }  // Namespace AM
 
 typedef enum {

--- a/Drivers/imu/inc/imu.hpp
+++ b/Drivers/imu/inc/imu.hpp
@@ -1,0 +1,52 @@
+/**
+ * IMU class definition / stub
+ * Designed to be extended by IMU devices
+ * Created by: Anthony Luo on 2024-04-18
+ * Maintained by:
+ * Last updated:
+*/
+
+#ifndef IMU_HPP
+#define IMU_HPP
+
+#include "CommonDataTypes.hpp"
+
+/************************************************
+ * Definitions
+ ************************************************/
+
+struct IMUData_t {
+    float gyrx, gyry, gyrz;
+    float accx, accy, accz;
+    float magx, magy, magz;
+
+    bool is_data_new;
+    SensorErrorCode sensor_status; // TODO: determine if we need this?
+};
+
+/************************************************
+ * Prototypes
+ ************************************************/
+class IMU{
+    public:
+        // Leaving the constructor to be elsewhere.... don't know how to handle passing SPI/I2C handles
+
+        /**
+         * Re-calibrates sensor. Useful if we need to hard re-set an IMU in-flight or something.
+        */
+        virtual SensorErrorCode calibrate() = 0;
+        /**
+         * Begins IMU data sampling. TODO: determine how this is determined
+         * Data should be stored in a buffer and accessible at any time.
+         * 
+        */
+        virtual void beginMeasuring() = 0;
+
+        /**
+         * Retrieves newest data stored by IMU.
+         * TODO: determine if we want to return error codes or if we want to set the struct
+        */
+        virtual SensorErrorCode getResult(IMUData_t &data) = 0;
+    private:
+        IMUData_t latest_data;
+};


### PR DESCRIPTION
Adds a IMU class template.

Largely lifted from ZP 1.0.

Need to know the following:
- How we want to return / express error states
- Whether or not we want to keep singleton architecture
- Where hardware SPI/I2C handles are defined
- How to create initializer and whether or not we want public `init` functions.
- How many folders we want under /drivers/